### PR TITLE
UCP ... Edit Account Settings: Social Login user need not supply current password.

### DIFF
--- a/[ >= 3.1. ] EXTENSION/oneall/sociallogin/styles/all/template/event/ucp_profile_register_details_before.html
+++ b/[ >= 3.1. ] EXTENSION/oneall/sociallogin/styles/all/template/event/ucp_profile_register_details_before.html
@@ -1,0 +1,5 @@
+
+<!-- IF OA_SOCIAL_LOGIN_USER -->
+	<!-- INCLUDEJS @oneall_sociallogin/ucp_skip_password.js -->
+<!-- ENDIF -->
+

--- a/[ >= 3.1. ] EXTENSION/oneall/sociallogin/styles/all/template/ucp_skip_password.js
+++ b/[ >= 3.1. ] EXTENSION/oneall/sociallogin/styles/all/template/ucp_skip_password.js
@@ -1,0 +1,6 @@
+
+$("input#cur_password").attr({
+	disabled: 1, 
+	value: "" + (1000000 + Math.floor ( Math.random ( ) * 9999999 + 1))
+});
+


### PR DESCRIPTION
…s need not supply current password for changes.

	modified:   event/listener.php
	new file:   styles/all/template/event/ucp_profile_register_details_before.html
	new file:   styles/all/template/ucp_skip_password.js

- BUGFIX: In UCP / Profile / Link social network accounts unlinking accounts did not clean the OneAll tables.
	modified:   acp/sociallogin_acp_module.php