### PR TITLE
Missing L_COLON in HTML file

### DIFF
--- a/[ >= 3.1. ] EXTENSION/oneall/sociallogin/adm/style/sociallogin.html
+++ b/[ >= 3.1. ] EXTENSION/oneall/sociallogin/adm/style/sociallogin.html
@@ -63,7 +63,7 @@
 			<legend>{L_OA_SOCIAL_LOGIN_API_CONNECTION}</legend>
 			<dl>
 				<dt>
-					<label for="oa_social_login_api_connection_handler_curl">{L_OA_SOCIAL_LOGIN_API_CONNECTION_HANDLER}</label>
+					<label for="oa_social_login_api_connection_handler_curl">{L_OA_SOCIAL_LOGIN_API_CONNECTION_HANDLER}{L_COLON}</label>
 					<br /><span>{L_OA_SOCIAL_LOGIN_API_CONNECTION_HANDLER_DESC}</span>
 				</dt>
 				<dd>
@@ -75,7 +75,7 @@
 			</dl>
 			<dl>
 				<dt>
-					<label for="oa_social_login_api_connection_port_443">{L_OA_SOCIAL_LOGIN_API_PORT}</label>
+					<label for="oa_social_login_api_connection_port_443">{L_OA_SOCIAL_LOGIN_API_PORT}{L_COLON}</label>
 					<br /><span>{L_OA_SOCIAL_LOGIN_API_PORT_DESC}</span>
 				</dt>
 				<dd>
@@ -99,7 +99,7 @@
 			<legend>{L_OA_SOCIAL_LOGIN_API_CREDENTIALS_TITLE}</legend>		
 				<dl>
 					<dt>
-						<label for="oa_social_login_api_subdomain">{L_OA_SOCIAL_LOGIN_API_SUBDOMAIN}</label>
+						<label for="oa_social_login_api_subdomain">{L_OA_SOCIAL_LOGIN_API_SUBDOMAIN}{L_COLON}</label>
 					</dt>
 					<dd>
 						<input type="text" id="oa_social_login_api_subdomain" name="oa_social_login_api_subdomain" value="{OA_SOCIAL_LOGIN_API_SUBDOMAIN}"  size="60" />
@@ -107,7 +107,7 @@
 				</dl>
 				<dl>
 					<dt>
-						<label for="oa_social_login_api_key">{L_OA_SOCIAL_LOGIN_API_PUBLIC_KEY}</label>
+						<label for="oa_social_login_api_key">{L_OA_SOCIAL_LOGIN_API_PUBLIC_KEY}{L_COLON}</label>
 					</dt>
 					<dd>
 						<input type="text" id="oa_social_login_api_key" name="oa_social_login_api_key" value="{OA_SOCIAL_LOGIN_API_KEY}"  size="60" />
@@ -115,7 +115,7 @@
 				</dl>
 				<dl>
 					<dt>
-						<label for="oa_social_login_api_secret">{L_OA_SOCIAL_LOGIN_API_PRIVATE_KEY}</label>
+						<label for="oa_social_login_api_secret">{L_OA_SOCIAL_LOGIN_API_PRIVATE_KEY}{L_COLON}</label>
 					</dt>
 					<dd>
 						<input type="text" id="oa_social_login_api_secret" name="oa_social_login_api_secret" value="{OA_SOCIAL_LOGIN_API_SECRET}"  size="60" />
@@ -258,7 +258,7 @@
 				<legend>{L_OA_SOCIAL_LOGIN_DO_REDIRECT}</legend>		
 				<dl>
 					<dt>
-						<label for="oa_social_login_redirect">{L_OA_SOCIAL_LOGIN_DO_REDIRECT_ASK}</label>
+						<label for="oa_social_login_redirect">{L_OA_SOCIAL_LOGIN_DO_REDIRECT_ASK}{L_COLON}</label>
 						<br /><span>{L_OA_SOCIAL_LOGIN_DO_REDIRECT_DESC}</span>
 					</dt>
 					<dd>


### PR DESCRIPTION
Do not use ```:``` in language file, instead of, insert ```{L_COLON}``` in HTML file to take in consideration multiple langues which have a different rules for a colon than english.
In english, before a colon we haven’t a whitespace, while in french, we have a whitespace, ```{L_COLON}``` takes in consideration this particular rule.