### PR TITLE
Fix the UCP module add part of the module migration

### DIFF
--- a/[ >= 3.1. ] EXTENSION/oneall/sociallogin/migrations/v10x/m3_initial_module.php
+++ b/[ >= 3.1. ] EXTENSION/oneall/sociallogin/migrations/v10x/m3_initial_module.php
@@ -6,7 +6,7 @@
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
+d * as published by the Free Software Foundation; either version 2
  * of the License, or (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
@@ -16,7 +16,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307,USA.
+o * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307,USA.
  *
  * The "GNU General Public License" (GPL) is available at
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
@@ -26,7 +26,7 @@ namespace oneall\sociallogin\migrations\v10x;
 
 /**
  * Migration stage 3: Initial module
- */
+m */
 class m3_initial_module extends \phpbb\db\migration\migration
 {
 	public function update_data ()
@@ -64,17 +64,8 @@ class m3_initial_module extends \phpbb\db\migration\migration
 				array (
 					'ucp',
 					'UCP_PROFILE',
-					'OA_SOCIAL_LOGIN_LINK_UCP'
-				)
-			),
-
-			// Add Settings link to Social Link group
-			array (
-				'module.add',
-				array (
-					'ucp',
-					'OA_SOCIAL_LOGIN_LINK_UCP',
 					array (
+						'module_langname' => 'OA_SOCIAL_LOGIN_LINK_UCP',
 						'module_basename' => '\oneall\sociallogin\ucp\sociallogin_ucp_module',
 						'modes' => array (
 							'settings'


### PR DESCRIPTION
The way modules actually get added in phpBB 3.1.10 slightly changed so the module migration needs updating for it to be installed in the latest version of phpBB.